### PR TITLE
Deploy system to production with https

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,31 @@
+## Django
+DEBUG=False
+SECRET_KEY=
+ALLOWED_HOSTS=localhost,127.0.0.1
+
+## Domain & HTTPS (for Caddy / Let's Encrypt)
+DOMAIN=
+ACME_EMAIL=
+SECURE_SSL_REDIRECT=True
+CSRF_TRUSTED_ORIGINS=https://localhost,http://localhost:8000,http://127.0.0.1:8000
+CORS_ALLOWED_ORIGINS=https://localhost,http://localhost:3000,http://127.0.0.1:3000
+
+## Database (Postgres in compose)
+POSTGRES_DB=app
+POSTGRES_USER=app
+POSTGRES_PASSWORD=changeme
+DATABASE_URL=postgres://app:changeme@db:5432/app
+CONN_MAX_AGE=60
+DB_SSL_REQUIRE=False
+
+## Redis / Celery / Channels
+REDIS_URL=redis://redis:6379/0
+
+## Static/Media
+COLLECTSTATIC=1
+
+## Django settings module
+DJANGO_SETTINGS_MODULE=noctis_pro.settings
 DEBUG=false
 DJANGO_SETTINGS_MODULE=noctis_pro.settings
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -25,6 +25,12 @@
 	}
 	header @static Cache-Control max-age=31536000
 
+	# Serve uploaded media files directly
+	handle_path /media/* {
+		root * /app
+		file_server
+	}
+
 	reverse_proxy web:8000
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - DJANGO_SETTINGS_MODULE=noctis_pro.settings
       - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     volumes:
       - .:/app
       - media:/app/media
@@ -19,6 +19,7 @@ services:
     depends_on:
       - redis
       - db
+    restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:8000/health/"]
       interval: 20s
@@ -36,17 +37,20 @@ services:
       - ACME_EMAIL=${ACME_EMAIL}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
+      - media:/app/media
       - caddy-data:/data
       - caddy-config:/config
     depends_on:
       - web
+    restart: unless-stopped
 
   redis:
     image: redis:7-alpine
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     volumes:
       - redis-data:/data
+    restart: unless-stopped
 
   db:
     image: postgres:15-alpine
@@ -57,7 +61,8 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
+    restart: unless-stopped
 
   worker:
     build: .
@@ -74,6 +79,7 @@ services:
     depends_on:
       - redis
       - db
+    restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "celery -A noctis_pro inspect ping | grep -q 'pong'"]
       interval: 30s


### PR DESCRIPTION
Harden Docker Compose stack for production deployment by restricting service exposure, adding restart policies, and configuring Caddy for HTTPS and media serving.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ad2dd06-4f14-4bb5-b6cf-b64b2da6386d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9ad2dd06-4f14-4bb5-b6cf-b64b2da6386d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

