### PR TITLE
Install noctis pro native script

### DIFF
--- a/deploy/install-native.sh
+++ b/deploy/install-native.sh
@@ -44,9 +44,6 @@ if [[ ! -f .env ]]; then
   fi
 fi
 
-# Clean up any existing malformed .env file
-clean_env
-
 # Helper function to clean up malformed .env files
 clean_env() {
   if [[ -f .env ]]; then
@@ -70,6 +67,9 @@ set_env() {
     echo "${key}=${value}" >> .env
   fi
 }
+
+# Clean up any existing malformed .env file
+clean_env
 
 # Generate SECRET_KEY if missing
 if ! grep -q '^SECRET_KEY=' .env || grep -q 'your-secret-key' .env; then


### PR DESCRIPTION
Move `clean_env` function call after its definition to resolve "command not found" error.

The `clean_env` function was called before it was defined in the script, leading to a "command not found" error during installation. This change reorders the script to ensure the function is defined before it is invoked.

---
<a href="https://cursor.com/background-agent?bcId=bc-2bf8d47e-42fc-49d7-a247-1af1ceb61337">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2bf8d47e-42fc-49d7-a247-1af1ceb61337">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

